### PR TITLE
Fix iPhone corner visibility and iPad frame selection

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -156,7 +156,8 @@ export default function buildCmd() {
                     frameMetadata: frameMetadata ? {
                       frameWidth: frameMetadata.frameWidth,
                       frameHeight: frameMetadata.frameHeight,
-                      screenRect: frameMetadata.screenRect
+                      screenRect: frameMetadata.screenRect,
+                      maskPath: frameMetadata.maskPath
                     } : undefined,
                     caption: opts.caption !== false ? captionText : undefined,
                     captionConfig: config.caption,

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -14,6 +14,7 @@ export interface ComposeOptions {
       width: number;
       height: number;
     };
+    maskPath?: string;
   };
   caption?: string;
   captionConfig: CaptionConfig;
@@ -106,26 +107,16 @@ export async function composeAppStoreScreenshot(options: ComposeOptions): Promis
       )
       .toBuffer();
 
-    // Composite screenshot into frame at original size
-    let deviceComposite = await sharp({
-      create: {
-        width: originalFrameWidth,
-        height: originalFrameHeight,
-        channels: 4,
-        background: { r: 0, g: 0, b: 0, alpha: 0 }
-      }
-    })
-      .png()
+    // Create the device composite by starting with the frame
+    // Then place the screenshot UNDER it using dest-over blend mode
+    // This ensures the frame bezels cover the screenshot edges
+    let deviceComposite = await sharp(frame)
       .composite([
         {
           input: resizedScreenshot,
           left: frameMetadata.screenRect.x,
-          top: frameMetadata.screenRect.y
-        },
-        {
-          input: frame,
-          left: 0,
-          top: 0
+          top: frameMetadata.screenRect.y,
+          blend: 'dest-over'  // Place screenshot behind frame
         }
       ])
       .toBuffer();

--- a/src/core/devices.ts
+++ b/src/core/devices.ts
@@ -19,6 +19,7 @@ export interface DeviceFrame {
   };
   deviceType: 'iphone' | 'ipad' | 'mac' | 'watch';
   originalName?: string;
+  maskPath?: string;
 }
 
 // Dynamic frame registry - will be populated from Frames.json
@@ -168,6 +169,70 @@ export async function getImageDimensions(imagePath: string): Promise<{ width: nu
   return { width, height, orientation };
 }
 
+// Map exact resolutions to specific devices
+const RESOLUTION_TO_DEVICE: Record<string, string> = {
+  // iPhone resolutions (portrait)
+  '1320x2868': 'iphone-16-pro-max',
+  '1206x2622': 'iphone-16-pro',
+  '1290x2796': 'iphone-15-pro-max',
+  '1179x2556': 'iphone-15-pro',
+  '1284x2778': 'iphone-14-plus',
+  '1170x2532': 'iphone-14',
+  '1125x2436': 'iphone-11-pro',
+  '1242x2688': 'iphone-11-pro-max',
+  '828x1792': 'iphone-11',
+  '1080x2340': 'iphone-12-mini',
+  '750x1334': 'iphone-8-and-2020-se',
+
+  // iPhone resolutions (landscape)
+  '2868x1320': 'iphone-16-pro-max-landscape',
+  '2622x1206': 'iphone-16-pro-landscape',
+  '2796x1290': 'iphone-15-pro-max-landscape',
+  '2556x1179': 'iphone-15-pro-landscape',
+  '2778x1284': 'iphone-14-plus-landscape',
+  '2532x1170': 'iphone-14-landscape',
+  '2436x1125': 'iphone-11-pro-landscape',
+  '2688x1242': 'iphone-11-pro-max-landscape',
+  '1792x828': 'iphone-11-landscape',
+  '2340x1080': 'iphone-12-mini-landscape',
+
+  // iPad resolutions (portrait)
+  '2048x2732': 'ipad pro 2018 2021',  // iPad Pro 12.9"
+  '1668x2388': 'ipad pro 2018 2021 11',  // iPad Pro 11"
+  '1640x2360': 'ipad air 2020',     // iPad Air
+  '1620x2160': 'ipad 2021',         // Regular iPad & iPad mini (same resolution)
+  '2064x2752': 'ipad pro 2024 11',  // iPad Pro 11" M4
+  '2420x3212': 'ipad pro 2024 13',  // iPad Pro 13" M4
+
+  // iPad resolutions (landscape)
+  '2732x2048': 'ipad pro 2018 2021',  // iPad Pro 12.9"
+  '2388x1668': 'ipad pro 2018 2021 11',  // iPad Pro 11"
+  '2360x1640': 'ipad air 2020',     // iPad Air
+  '2160x1620': 'ipad 2021',         // Regular iPad & iPad mini (same resolution)
+  '2752x2064': 'ipad pro 2024 13',  // iPad Pro 13" M4
+  '3212x2420': 'ipad pro 2024 13',  // iPad Pro 13" M4
+
+  // Mac resolutions
+  '3456x2234': 'macbook-pro-16',
+  '3024x1964': 'macbook-pro-14',
+  '2880x1864': 'macbook-air-15',
+  '2560x1664': 'macbook-air-13',
+  '4480x2520': 'imac-24',
+
+  // Watch resolutions
+  '410x502': 'watch-ultra',
+  '396x484': 'watch-series-9-45mm',
+  '368x448': 'watch-series-9-41mm'
+};
+
+/**
+ * Detect exact device from screenshot resolution
+ */
+function detectExactDevice(width: number, height: number): string | null {
+  const key = `${width}x${height}`;
+  return RESOLUTION_TO_DEVICE[key] || null;
+}
+
 /**
  * Find best matching frame for a screenshot
  */
@@ -178,6 +243,48 @@ export function findBestFrame(
   preferredFrame?: string
 ): DeviceFrame | null {
   const orientation = detectOrientation(screenshotWidth, screenshotHeight);
+
+  // First try exact resolution matching
+  const exactDevice = detectExactDevice(screenshotWidth, screenshotHeight);
+  if (exactDevice) {
+    console.log(`    Detected exact device: ${exactDevice} from resolution ${screenshotWidth}x${screenshotHeight}`);
+
+    // Find frame that matches this exact device AND orientation
+    let exactFrame = frameRegistry.find(f => {
+      const normalizedName = f.name.toLowerCase().replace(/-/g, ' ');
+      const searchName = exactDevice.toLowerCase().replace(/-/g, ' ');
+      const nameMatches = normalizedName.includes(searchName) ||
+                          (f.originalName && f.originalName.toLowerCase().includes(searchName));
+      // Must match both name AND orientation
+      return nameMatches && f.orientation === orientation;
+    });
+
+    // Special case: For 2752x2064 (iPad Pro 13" M4), ensure we don't get the 11" frame
+    if (screenshotWidth === 2752 && screenshotHeight === 2064) {
+      // Try to find iPad Pro 2024 13 Landscape frame first
+      const ipad13Frame = frameRegistry.find(f =>
+        (f.displayName === 'iPad Pro 2024 13 Landscape' ||
+         f.originalName === 'iPad Pro 2024 13 Landscape') &&
+        f.orientation === 'landscape'
+      );
+
+      if (ipad13Frame) {
+        exactFrame = ipad13Frame;
+      } else {
+        // Fall back to the larger 12.9" frame if 13" not found
+        exactFrame = frameRegistry.find(f =>
+          f.displayName === 'iPad Pro 2018-2021 Landscape' &&
+          f.orientation === 'landscape' &&
+          !f.displayName.includes('11')
+        );
+      }
+    }
+
+    if (exactFrame) {
+      console.log(`    Found exact frame: ${exactFrame.displayName}`);
+      return exactFrame;
+    }
+  }
 
   // If preferred frame specified, check if it matches orientation
   if (preferredFrame) {
@@ -211,7 +318,16 @@ export function findBestFrame(
   // Calculate aspect ratio of screenshot
   const aspectRatio = screenshotWidth / screenshotHeight;
 
-  // Find frame with closest aspect ratio match
+  // Find frame with exact resolution match first
+  for (const frame of candidates) {
+    if (frame.screenRect.width === screenshotWidth &&
+        frame.screenRect.height === screenshotHeight) {
+      console.log(`    Found exact resolution match: ${frame.displayName}`);
+      return frame;
+    }
+  }
+
+  // Otherwise find frame with closest aspect ratio match
   let bestFrame = candidates[0];
   let bestDiff = Math.abs((bestFrame.screenRect.width / bestFrame.screenRect.height) - aspectRatio);
 

--- a/src/core/devices.ts
+++ b/src/core/devices.ts
@@ -244,7 +244,23 @@ export function findBestFrame(
 ): DeviceFrame | null {
   const orientation = detectOrientation(screenshotWidth, screenshotHeight);
 
-  // First try exact resolution matching
+  // If preferred frame specified, check if it matches orientation first
+  if (preferredFrame) {
+    const preferred = frameRegistry.find(f => f.name === preferredFrame);
+    if (preferred) {
+      // Warn if orientation mismatch
+      if (preferred.orientation !== orientation) {
+        console.warn(
+          `Warning: Preferred frame '${preferredFrame}' is ${preferred.orientation} but screenshot is ${orientation}`
+        );
+        // Don't use mismatched frame
+      } else if (preferred.deviceType === deviceType) {
+        return preferred;
+      }
+    }
+  }
+
+  // Try exact resolution matching
   const exactDevice = detectExactDevice(screenshotWidth, screenshotHeight);
   if (exactDevice) {
     console.log(`    Detected exact device: ${exactDevice} from resolution ${screenshotWidth}x${screenshotHeight}`);
@@ -286,21 +302,6 @@ export function findBestFrame(
     }
   }
 
-  // If preferred frame specified, check if it matches orientation
-  if (preferredFrame) {
-    const preferred = frameRegistry.find(f => f.name === preferredFrame);
-    if (preferred) {
-      // Warn if orientation mismatch
-      if (preferred.orientation !== orientation) {
-        console.warn(
-          `Warning: Preferred frame '${preferredFrame}' is ${preferred.orientation} but screenshot is ${orientation}`
-        );
-        // Don't use mismatched frame
-      } else if (preferred.deviceType === deviceType) {
-        return preferred;
-      }
-    }
-  }
 
   // Find frames matching device type and orientation
   const candidates = frameRegistry.filter(f =>

--- a/src/core/frames-loader.ts
+++ b/src/core/frames-loader.ts
@@ -172,8 +172,11 @@ export async function buildFrameRegistry(framesDir: string) {
           if (dimensions) {
             // Get the actual screenshot dimensions for this device
             const screenshotDims = getScreenshotDimensions(frame.name, orientationKey);
-            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
-            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+            const calculatedWidth = dimensions.width - (parseInt(frame.x) || 0) * 2;
+            const calculatedHeight = dimensions.height - (parseInt(frame.y) || 0) * 2;
+            // Use the smaller of the fixed resolution or calculated resolution
+            const screenWidth = screenshotDims.width ? Math.min(screenshotDims.width, calculatedWidth) : calculatedWidth;
+            const screenHeight = screenshotDims.height ? Math.min(screenshotDims.height, calculatedHeight) : calculatedHeight;
 
             // Check if mask file exists
             const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
@@ -216,8 +219,11 @@ export async function buildFrameRegistry(framesDir: string) {
             if (dimensions) {
               // Get the actual screenshot dimensions for this device
               const screenshotDims = getScreenshotDimensions(frame.name, 'portrait');
-              const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
-              const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+              const calculatedWidth = dimensions.width - (parseInt(frame.x) || 0) * 2;
+              const calculatedHeight = dimensions.height - (parseInt(frame.y) || 0) * 2;
+              // Use the smaller of the fixed resolution or calculated resolution
+              const screenWidth = screenshotDims.width ? Math.min(screenshotDims.width, calculatedWidth) : calculatedWidth;
+              const screenHeight = screenshotDims.height ? Math.min(screenshotDims.height, calculatedHeight) : calculatedHeight;
 
               // Check if mask file exists
               const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
@@ -252,8 +258,11 @@ export async function buildFrameRegistry(framesDir: string) {
             if (dimensions) {
               // Get the actual screenshot dimensions for this device
               const screenshotDims = getScreenshotDimensions(frame.name, 'landscape');
-              const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
-              const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+              const calculatedWidth = dimensions.width - (parseInt(frame.x) || 0) * 2;
+              const calculatedHeight = dimensions.height - (parseInt(frame.y) || 0) * 2;
+              // Use the smaller of the fixed resolution or calculated resolution
+              const screenWidth = screenshotDims.width ? Math.min(screenshotDims.width, calculatedWidth) : calculatedWidth;
+              const screenHeight = screenshotDims.height ? Math.min(screenshotDims.height, calculatedHeight) : calculatedHeight;
 
               // Check if mask file exists
               const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
@@ -296,8 +305,11 @@ export async function buildFrameRegistry(framesDir: string) {
           if (dimensions) {
             // Get the actual screenshot dimensions for this device
             const screenshotDims = getScreenshotDimensions(frame.name, 'portrait');
-            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
-            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+            const calculatedWidth = dimensions.width - (parseInt(frame.x) || 0) * 2;
+            const calculatedHeight = dimensions.height - (parseInt(frame.y) || 0) * 2;
+            // Use the smaller of the fixed resolution or calculated resolution
+            const screenWidth = screenshotDims.width ? Math.min(screenshotDims.width, calculatedWidth) : calculatedWidth;
+            const screenHeight = screenshotDims.height ? Math.min(screenshotDims.height, calculatedHeight) : calculatedHeight;
 
             // Check if mask file exists
             const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
@@ -332,8 +344,11 @@ export async function buildFrameRegistry(framesDir: string) {
           if (dimensions) {
             // Get the actual screenshot dimensions for this device
             const screenshotDims = getScreenshotDimensions(frame.name, 'landscape');
-            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
-            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+            const calculatedWidth = dimensions.width - (parseInt(frame.x) || 0) * 2;
+            const calculatedHeight = dimensions.height - (parseInt(frame.y) || 0) * 2;
+            // Use the smaller of the fixed resolution or calculated resolution
+            const screenWidth = screenshotDims.width ? Math.min(screenshotDims.width, calculatedWidth) : calculatedWidth;
+            const screenHeight = screenshotDims.height ? Math.min(screenshotDims.height, calculatedHeight) : calculatedHeight;
 
             // Check if mask file exists
             const maskPath = path.join(framesDir, `${frame.name}_mask.png`);

--- a/src/core/frames-loader.ts
+++ b/src/core/frames-loader.ts
@@ -18,6 +18,91 @@ export interface FramesData {
   version?: string;
 }
 
+// Device screenshot resolutions based on Apple's official specifications
+const DEVICE_RESOLUTIONS: Record<string, { portrait: { width: number; height: number }; landscape?: { width: number; height: number } }> = {
+  // iPhone 16 Series
+  'iphone 16 pro max': { portrait: { width: 1320, height: 2868 }, landscape: { width: 2868, height: 1320 } },
+  'iphone 16 pro': { portrait: { width: 1206, height: 2622 }, landscape: { width: 2622, height: 1206 } },
+  'iphone 16 plus': { portrait: { width: 1290, height: 2796 }, landscape: { width: 2796, height: 1290 } },
+  'iphone 16': { portrait: { width: 1179, height: 2556 }, landscape: { width: 2556, height: 1179 } },
+
+  // iPhone 15 Series
+  'iphone 15 pro max': { portrait: { width: 1290, height: 2796 }, landscape: { width: 2796, height: 1290 } },
+  'iphone 15 pro': { portrait: { width: 1179, height: 2556 }, landscape: { width: 2556, height: 1179 } },
+  'iphone 15 plus': { portrait: { width: 1290, height: 2796 }, landscape: { width: 2796, height: 1290 } },
+  'iphone 15': { portrait: { width: 1179, height: 2556 }, landscape: { width: 2556, height: 1179 } },
+
+  // iPhone 14 Series
+  'iphone 14 pro max': { portrait: { width: 1290, height: 2796 }, landscape: { width: 2796, height: 1290 } },
+  'iphone 14 pro': { portrait: { width: 1179, height: 2556 }, landscape: { width: 2556, height: 1179 } },
+  'iphone 14 plus': { portrait: { width: 1284, height: 2778 }, landscape: { width: 2778, height: 1284 } },
+  'iphone 14': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+
+  // iPhone 13 Series
+  'iphone 13 pro max': { portrait: { width: 1284, height: 2778 }, landscape: { width: 2778, height: 1284 } },
+  'iphone 13 pro': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+  'iphone 13': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+  'iphone 13 mini': { portrait: { width: 1080, height: 2340 }, landscape: { width: 2340, height: 1080 } },
+
+  // iPhone 12 Series
+  'iphone 12 pro max': { portrait: { width: 1284, height: 2778 }, landscape: { width: 2778, height: 1284 } },
+  'iphone 12 pro': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+  'iphone 12': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+  'iphone 12 mini': { portrait: { width: 1080, height: 2340 }, landscape: { width: 2340, height: 1080 } },
+
+  // Grouped models (from Frames.json naming)
+  'iphone 12-13 pro max': { portrait: { width: 1284, height: 2778 }, landscape: { width: 2778, height: 1284 } },
+  'iphone 12-13 pro': { portrait: { width: 1170, height: 2532 }, landscape: { width: 2532, height: 1170 } },
+  'iphone 12-13 mini': { portrait: { width: 1080, height: 2340 }, landscape: { width: 2340, height: 1080 } },
+
+  // iPhone 11 Series
+  'iphone 11 pro max': { portrait: { width: 1242, height: 2688 }, landscape: { width: 2688, height: 1242 } },
+  'iphone 11 pro': { portrait: { width: 1125, height: 2436 }, landscape: { width: 2436, height: 1125 } },
+  'iphone 11': { portrait: { width: 828, height: 1792 }, landscape: { width: 1792, height: 828 } },
+
+  // iPhone SE/8
+  'iphone 8 and 2020 se': { portrait: { width: 750, height: 1334 } },
+  'iphone se': { portrait: { width: 750, height: 1334 } },
+
+  // iPad resolutions
+  'ipad pro 2018-2021': { portrait: { width: 2048, height: 2732 }, landscape: { width: 2732, height: 2048 } },
+  'ipad pro 2018-2021 11': { portrait: { width: 1668, height: 2388 }, landscape: { width: 2388, height: 1668 } },
+  'ipad pro 2024 11': { portrait: { width: 2064, height: 2752 }, landscape: { width: 2752, height: 2064 } },
+  'ipad pro 2024 13': { portrait: { width: 2064, height: 2752 }, landscape: { width: 2752, height: 2064 } },
+  'ipad air 2020': { portrait: { width: 1640, height: 2360 }, landscape: { width: 2360, height: 1640 } },
+  'ipad mini 2021': { portrait: { width: 1620, height: 2160 }, landscape: { width: 2160, height: 1620 } },
+  'ipad 2021': { portrait: { width: 1620, height: 2160 }, landscape: { width: 2160, height: 1620 } },
+
+  // Mac resolutions
+  'macbook pro 2021 16': { portrait: { width: 3456, height: 2234 } },
+  'macbook pro 2021 14': { portrait: { width: 3024, height: 1964 } },
+  'macbook air 2022': { portrait: { width: 2560, height: 1664 } },
+  'imac 2021': { portrait: { width: 4480, height: 2520 } },
+
+  // Default fallback
+  'default': { portrait: { width: 0, height: 0 } }
+};
+
+/**
+ * Get screenshot dimensions for a specific device and orientation
+ */
+function getScreenshotDimensions(frameName: string, orientation: 'portrait' | 'landscape'): { width: number; height: number } {
+  const normalizedName = frameName.toLowerCase();
+
+  // Find matching device resolution
+  for (const [key, res] of Object.entries(DEVICE_RESOLUTIONS)) {
+    if (normalizedName.includes(key)) {
+      if (orientation === 'landscape' && res.landscape) {
+        return res.landscape;
+      }
+      return res.portrait;
+    }
+  }
+
+  // Return 0,0 to indicate we need to fall back to calculation
+  return { width: 0, height: 0 };
+}
+
 /**
  * Load and parse the Frames.json metadata
  */
@@ -85,6 +170,15 @@ export async function buildFrameRegistry(framesDir: string) {
           const dimensions = await getFrameDimensions(framePath);
 
           if (dimensions) {
+            // Get the actual screenshot dimensions for this device
+            const screenshotDims = getScreenshotDimensions(frame.name, orientationKey);
+            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
+            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+
+            // Check if mask file exists
+            const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
+            const maskExists = await fs.access(maskPath).then(() => true).catch(() => false);
+
             registry.push({
               name: frame.name.toLowerCase().replace(/ /g, '-'),
               displayName: frame.name,
@@ -94,11 +188,12 @@ export async function buildFrameRegistry(framesDir: string) {
               screenRect: {
                 x: parseInt(frame.x) || 0,
                 y: parseInt(frame.y) || 0,
-                width: dimensions.width - (parseInt(frame.x) || 0) * 2,
-                height: dimensions.height - (parseInt(frame.y) || 0) * 2
+                width: screenWidth,
+                height: screenHeight
               },
               deviceType: 'iphone' as const,
-              originalName: frame.name
+              originalName: frame.name,
+              maskPath: maskExists ? maskPath : undefined
             });
           }
         }
@@ -119,6 +214,15 @@ export async function buildFrameRegistry(framesDir: string) {
             const dimensions = await getFrameDimensions(framePath);
 
             if (dimensions) {
+              // Get the actual screenshot dimensions for this device
+              const screenshotDims = getScreenshotDimensions(frame.name, 'portrait');
+              const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
+              const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+
+              // Check if mask file exists
+              const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
+              const maskExists = await fs.access(maskPath).then(() => true).catch(() => false);
+
               registry.push({
                 name: frame.name.toLowerCase().replace(/ /g, '-'),
                 displayName: frame.name,
@@ -128,11 +232,12 @@ export async function buildFrameRegistry(framesDir: string) {
                 screenRect: {
                   x: parseInt(frame.x) || 0,
                   y: parseInt(frame.y) || 0,
-                  width: dimensions.width - (parseInt(frame.x) || 0) * 2,
-                  height: dimensions.height - (parseInt(frame.y) || 0) * 2
+                  width: screenWidth,
+                  height: screenHeight
                 },
                 deviceType: 'iphone' as const,
-                originalName: frame.name
+                originalName: frame.name,
+                maskPath: maskExists ? maskPath : undefined
               });
             }
           }
@@ -145,6 +250,15 @@ export async function buildFrameRegistry(framesDir: string) {
             const dimensions = await getFrameDimensions(framePath);
 
             if (dimensions) {
+              // Get the actual screenshot dimensions for this device
+              const screenshotDims = getScreenshotDimensions(frame.name, 'landscape');
+              const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
+              const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+
+              // Check if mask file exists
+              const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
+              const maskExists = await fs.access(maskPath).then(() => true).catch(() => false);
+
               registry.push({
                 name: frame.name.toLowerCase().replace(/ /g, '-'),
                 displayName: frame.name,
@@ -154,11 +268,12 @@ export async function buildFrameRegistry(framesDir: string) {
                 screenRect: {
                   x: parseInt(frame.x) || 0,
                   y: parseInt(frame.y) || 0,
-                  width: dimensions.width - (parseInt(frame.x) || 0) * 2,
-                  height: dimensions.height - (parseInt(frame.y) || 0) * 2
+                  width: screenWidth,
+                  height: screenHeight
                 },
                 deviceType: 'iphone' as const,
-                originalName: frame.name
+                originalName: frame.name,
+                maskPath: maskExists ? maskPath : undefined
               });
             }
           }
@@ -179,6 +294,15 @@ export async function buildFrameRegistry(framesDir: string) {
           const dimensions = await getFrameDimensions(framePath);
 
           if (dimensions) {
+            // Get the actual screenshot dimensions for this device
+            const screenshotDims = getScreenshotDimensions(frame.name, 'portrait');
+            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
+            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+
+            // Check if mask file exists
+            const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
+            const maskExists = await fs.access(maskPath).then(() => true).catch(() => false);
+
             registry.push({
               name: frame.name.toLowerCase().replace(/ /g, '-'),
               displayName: frame.name,
@@ -188,11 +312,12 @@ export async function buildFrameRegistry(framesDir: string) {
               screenRect: {
                 x: parseInt(frame.x) || 0,
                 y: parseInt(frame.y) || 0,
-                width: dimensions.width - (parseInt(frame.x) || 0) * 2,
-                height: dimensions.height - (parseInt(frame.y) || 0) * 2
+                width: screenWidth,
+                height: screenHeight
               },
               deviceType: 'ipad' as const,
-              originalName: frame.name
+              originalName: frame.name,
+              maskPath: maskExists ? maskPath : undefined
             });
           }
         }
@@ -205,6 +330,15 @@ export async function buildFrameRegistry(framesDir: string) {
           const dimensions = await getFrameDimensions(framePath);
 
           if (dimensions) {
+            // Get the actual screenshot dimensions for this device
+            const screenshotDims = getScreenshotDimensions(frame.name, 'landscape');
+            const screenWidth = screenshotDims.width || (dimensions.width - (parseInt(frame.x) || 0) * 2);
+            const screenHeight = screenshotDims.height || (dimensions.height - (parseInt(frame.y) || 0) * 2);
+
+            // Check if mask file exists
+            const maskPath = path.join(framesDir, `${frame.name}_mask.png`);
+            const maskExists = await fs.access(maskPath).then(() => true).catch(() => false);
+
             registry.push({
               name: frame.name.toLowerCase().replace(/ /g, '-'),
               displayName: frame.name,
@@ -214,11 +348,12 @@ export async function buildFrameRegistry(framesDir: string) {
               screenRect: {
                 x: parseInt(frame.x) || 0,
                 y: parseInt(frame.y) || 0,
-                width: dimensions.width - (parseInt(frame.x) || 0) * 2,
-                height: dimensions.height - (parseInt(frame.y) || 0) * 2
+                width: screenWidth,
+                height: screenHeight
               },
               deviceType: 'ipad' as const,
-              originalName: frame.name
+              originalName: frame.name,
+              maskPath: maskExists ? maskPath : undefined
             });
           }
         }


### PR DESCRIPTION
## Summary
- Attempted to fix iPhone screenshot corners showing outside frame bezels
- Fixed iPad Pro 13" frame selection issue (now correctly maps 2752x2064 resolution)
- Added comprehensive device resolution mapping for accurate frame selection

## Changes Made
1. **iPhone Corner Fix Attempt**: Implemented `dest-over` blend mode to place screenshot behind frame, ensuring frame bezels should cover screenshot edges
2. **Device Resolution Mapping**: Added exact resolution-to-device mapping for all current Apple devices
3. **Frame Loader Enhancements**: 
   - Added mask detection for future masking implementation
   - Fixed device resolution calculations using official Apple specifications
4. **iPad Pro 13" Fix**: Correctly identifies and maps iPad Pro 13" screenshots (2752x2064)

## Known Issues
⚠️ **iPhone corner issue persists** - Despite using dest-over blend mode, corners are still visible. This PR includes the latest attempt, but further investigation is needed.

## Test Plan
- [ ] Build the project: `npm run build`
- [ ] Link CLI: `npm link`
- [ ] Test with iPhone screenshots to verify corner handling
- [ ] Test with iPad Pro 13" screenshots (2752x2064) to verify correct frame selection
- [ ] Verify other device frames still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)