### PR TITLE
fix: Update default resolutions to match current App Store requirements (v0.8.7)

### DIFF
--- a/.appshot/config.json
+++ b/.appshot/config.json
@@ -18,7 +18,7 @@
   "devices": {
     "iphone": {
       "input": "./screenshots/iphone",
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": true
     },
     "ipad": {
@@ -33,7 +33,7 @@
     },
     "watch": {
       "input": "./screenshots/watch",
-      "resolution": "368x448",
+      "resolution": "410x502",
       "autoFrame": true
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7] - 2025-09-04
+
+### 🐛 Bug Fixes
+- **Default Resolutions**: Updated default iPhone resolution from 1284x2778 to 1290x2796 to match current App Store requirements (iPhone 6.9" display)
+- **Watch Resolution**: Updated default Apple Watch resolution from 368x448 to 410x502 (Apple Watch Ultra) for latest devices
+- **Caption Structure**: Fixed issue where caption command was creating incorrect file structure with language keys at top level
+
+### 🛠️ Improvements
+- **App Store Compliance**: All default device resolutions now match the latest App Store screenshot specifications
+- **Test Updates**: Updated all test files to use the new correct resolutions
+- **Documentation**: Updated README and CLAUDE.md with corrected resolution values
+
 ## [0.8.6] - 2025-09-04
 
 ### ✨ New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,54 @@ appshot clean       # Remove final/ directory
 appshot clean --all # Remove all generated files
 ```
 
+## Project Structure
+
+### Source Code Structure (appshot package)
+```
+appshot/
+├── src/
+│   ├── cli.ts              # Entry point
+│   ├── commands/           # Command implementations
+│   ├── core/               # Core functionality
+│   ├── services/           # Services (fonts, translation, etc)
+│   ├── types/              # TypeScript type definitions
+│   ├── utils/              # Utility functions
+│   └── types.ts            # Main type definitions
+├── tests/                  # Test files
+│   ├── integration/        # Integration tests
+│   └── visual/             # Visual regression tests
+├── fonts/                  # Embedded font files (10+ families)
+├── frames/                 # Bundled device frame images
+└── assets/                 # Static assets and specifications
+```
+
+### User Project Structure (created by appshot)
+```
+your-project/
+├── .appshot/
+│   ├── config.json          # Main configuration
+│   ├── captions/            # Device-specific captions
+│   │   ├── iphone.json
+│   │   ├── ipad.json
+│   │   ├── mac.json
+│   │   └── watch.json
+│   ├── caption-history.json # Autocomplete history (created on use)
+│   ├── ai-config.json       # AI translation settings (optional)
+│   ├── processed/           # Watch mode tracking (macOS only)
+│   └── watch.pid            # Watch service PID (macOS only)
+├── screenshots/             # Your original screenshots
+│   ├── iphone/
+│   │   └── background.png  # Optional device background
+│   ├── ipad/
+│   ├── mac/
+│   └── watch/
+└── final/                   # Generated output
+    └── <device>/
+        └── <language>/      # Always uses language subdirectories
+```
+
+Note: Device frames are bundled with appshot - users don't need a local frames directory.
+
 ## Architecture
 
 ### Core Pipeline
@@ -136,7 +184,7 @@ appshot clean --all # Remove all generated files
   "devices": {
     "iphone": {
       "input": "./screenshots/iphone",
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": true,
       "partialFrame": false,
       "frameOffset": 25,

--- a/README.md
+++ b/README.md
@@ -1676,7 +1676,7 @@ cat > .appshot/config.json << EOF
 {
   "gradient": {"colors": ["#FF5733", "#FFC300"]},
   "devices": {
-    "iphone": {"resolution": "1284x2778"}
+    "iphone": {"resolution": "1290x2796"}
   }
 }
 EOF
@@ -1714,7 +1714,7 @@ def generate_screenshots(device, captions):
     config = {
         "gradient": {"colors": ["#0077BE", "#33CCCC"]},
         "devices": {
-            device: {"resolution": "1284x2778"}
+            device: {"resolution": "1290x2796"}
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ final/
 
 ### Project Structure
 
-Appshot uses a simple, predictable directory structure:
+Appshot creates and manages the following directory structure in your project:
 
 ```
 your-project/
@@ -178,15 +178,37 @@ your-project/
 │   ├── config.json          # Main configuration
 │   ├── captions/            # Device-specific captions
 │   │   ├── iphone.json
-│   │   └── ipad.json
-│   └── caption-history.json # Autocomplete history
-├── screenshots/             # Original screenshots
+│   │   ├── ipad.json
+│   │   ├── mac.json
+│   │   └── watch.json
+│   ├── caption-history.json # Autocomplete history (created on use)
+│   ├── ai-config.json       # AI translation settings (optional)
+│   ├── processed/           # Watch mode tracking (macOS only)
+│   └── watch.pid            # Watch service PID (macOS only)
+├── screenshots/             # Your original screenshots
 │   ├── iphone/
+│   │   └── background.png  # Optional device background
 │   ├── ipad/
-│   └── mac/
-├── frames/                  # Device frames (auto-downloaded)
+│   ├── mac/
+│   └── watch/
 └── final/                   # Generated output
+    ├── iphone/
+    │   ├── en/              # Language subdirectory (always created)
+    │   ├── es/              # Additional languages as needed
+    │   └── fr/
+    └── ipad/
+        └── en/
 ```
+
+**Created by `appshot init`:**
+- `.appshot/` directory with config.json
+- `.appshot/captions/` with device JSON files
+- `screenshots/` directories for each device type
+
+**Created during usage:**
+- `final/` - Created when you run `appshot build`
+- `.appshot/caption-history.json` - Created when using captions
+- `.appshot/processed/` - Created by watch mode (macOS)
 
 ### Configuration Overview
 
@@ -207,7 +229,7 @@ All settings are stored in `.appshot/config.json`:
   },
   "devices": {
     "iphone": {
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": true
     }
   }
@@ -1468,7 +1490,7 @@ appshot validate [options]
   "devices": {
     "iphone": {
       "input": "./screenshots/iphone",
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": true,
       "preferredFrame": "frame-name",
       "partialFrame": false,
@@ -1498,7 +1520,7 @@ Each device can override global settings:
     "iphone": {
       // Required
       "input": "./screenshots/iphone",
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       
       // Frame options
       "autoFrame": true,
@@ -1802,7 +1824,7 @@ For identical device positioning across all screenshots:
 {
   "devices": {
     "iphone": {
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": false,
       "preferredFrame": "iphone-16-pro-max-portrait",
       "frameScale": 0.85,
@@ -2050,12 +2072,25 @@ appshot/
 ├── src/
 │   ├── cli.ts              # Entry point
 │   ├── commands/           # Command implementations
-│   ├── core/              # Core functionality
-│   ├── services/          # Services (fonts, translation)
-│   └── types.ts           # TypeScript definitions
-├── tests/                 # Test files
-├── frames/               # Device frame images
-└── examples/            # Example projects
+│   ├── core/               # Core functionality
+│   ├── services/           # Services (fonts, translation, etc)
+│   ├── types/              # TypeScript type definitions
+│   ├── utils/              # Utility functions
+│   └── types.ts            # Main type definitions
+├── tests/                  # Test files
+│   ├── integration/        # Integration tests
+│   └── visual/             # Visual regression tests
+├── fonts/                  # Embedded font files
+│   ├── Inter/
+│   ├── Poppins/
+│   ├── Montserrat/
+│   └── ...                 # 10+ font families
+├── frames/                 # Device frame images
+├── assets/                 # Static assets
+│   ├── specs/              # App Store specifications
+│   └── frames/             # Frame metadata
+└── examples/               # Example projects
+    └── minimal-project/    # Basic example setup
 ```
 
 ### Testing

--- a/examples/watch-config.json
+++ b/examples/watch-config.json
@@ -16,7 +16,7 @@
   "devices": {
     "iphone": {
       "input": "./screenshots/iphone",
-      "resolution": "1284x2778",
+      "resolution": "1290x2796",
       "autoFrame": true
     },
     "ipad": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appshot-cli",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Generate App Store–ready screenshots with frames, gradients, and captions",
   "bin": {
     "appshot": "bin/appshot.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ ${pc.bold('Common Workflows:')}
   $ appshot watch start --process             # Auto-process new screenshots` : ''}
 
 ${pc.dim('Docs: https://github.com/chrisvanbuskirk/appshot')}`)
-  .version('0.8.6')
+  .version('0.8.7')
   .addHelpText('after', `\n${pc.bold('Environment Variables:')}
   OPENAI_API_KEY              API key for translation features
   APPSHOT_DISABLE_FONT_SCAN   Skip system font detection (CI optimization)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -49,10 +49,10 @@ ${pc.bold('Next Steps:')}
             paddingTop: 100
           },
           devices: {
-            iphone: { input: './screenshots/iphone', resolution: '1284x2778', autoFrame: true },
+            iphone: { input: './screenshots/iphone', resolution: '1290x2796', autoFrame: true },
             ipad:   { input: './screenshots/ipad',   resolution: '2048x2732', autoFrame: true },
             mac:    { input: './screenshots/mac',    resolution: '2880x1800', autoFrame: true },
-            watch:  { input: './screenshots/watch',  resolution: '368x448', autoFrame: true }
+            watch:  { input: './screenshots/watch',  resolution: '410x502', autoFrame: true }
           }
         };
 

--- a/src/services/doctor.ts
+++ b/src/services/doctor.ts
@@ -578,7 +578,7 @@ export class DoctorService {
 
     return {
       timestamp: new Date().toISOString(),
-      version: '0.8.6',
+      version: '0.8.7',
       platform: platform(),
       checks: categorizedChecks,
       summary,

--- a/tests/background-integration.test.ts
+++ b/tests/background-integration.test.ts
@@ -537,7 +537,7 @@ describe('background integration', () => {
     
     const deviceConfig: DeviceConfig = {
       input: tempDir,
-      resolution: '368x448'
+      resolution: '410x502'
     };
     
     const result = await composeAppStoreScreenshot({

--- a/tests/caption-styling.test.ts
+++ b/tests/caption-styling.test.ts
@@ -26,7 +26,7 @@ describe('Caption Styling', () => {
       devices: {
         iphone: {
           input: './screenshots/iphone',
-          resolution: '1284x2778',
+          resolution: '1290x2796',
           autoFrame: true
         }
       }

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -36,7 +36,7 @@ describe('files', () => {
         gradient: { colors: ['#000', '#fff'], direction: 'top-bottom' },
         caption: { font: 'Arial', fontsize: 48, color: '#000', align: 'center', paddingTop: 50 },
         devices: {
-          iphone: { input: './screenshots/iphone', resolution: '1284x2778' }
+          iphone: { input: './screenshots/iphone', resolution: '1290x2796' }
         }
       };
       

--- a/tests/font-localization.test.ts
+++ b/tests/font-localization.test.ts
@@ -50,12 +50,12 @@ describe('Font Localization', () => {
       },
       deviceConfig: {
         input: './screenshots/test',
-        resolution: '1284x2778',
+        resolution: '1290x2796',
         autoFrame: true,
         captionFont: 'Arial' // Device-specific font - should override global
       },
-      outputWidth: 1284,
-      outputHeight: 2778
+      outputWidth: 1290,
+      outputHeight: 2796
     });
 
     expect(result).toBeInstanceOf(Buffer);
@@ -95,12 +95,12 @@ describe('Font Localization', () => {
       },
       deviceConfig: {
         input: './screenshots/test',
-        resolution: '1284x2778',
+        resolution: '1290x2796',
         autoFrame: true
         // No captionFont specified - should use global font
       },
-      outputWidth: 1284,
-      outputHeight: 2778
+      outputWidth: 1290,
+      outputHeight: 2796
     });
 
     expect(result).toBeInstanceOf(Buffer);
@@ -148,7 +148,7 @@ describe('Font Localization', () => {
         },
         deviceConfig: {
           input: './screenshots/test',
-          resolution: '1284x2778',
+          resolution: '1290x2796',
           autoFrame: true,
           captionFont: 'Impact' // Device-specific font should apply to all languages
         },

--- a/tests/gradients-command.test.ts
+++ b/tests/gradients-command.test.ts
@@ -31,7 +31,7 @@ describe('gradients command', () => {
       devices: {
         iphone: {
           input: './screenshots/iphone',
-          resolution: '1284x2778'
+          resolution: '1290x2796'
         }
       }
     }, null, 2));


### PR DESCRIPTION
## Summary
- Updated default iPhone resolution to match current App Store requirements
- Updated Apple Watch resolution to latest Watch Ultra specs  
- Fixed outdated resolution values throughout codebase

## Changes
- **iPhone**: `1284x2778` → `1290x2796` (current 6.9" display requirement)
- **Apple Watch**: `368x448` → `410x502` (Apple Watch Ultra)
- Updated all test files to use correct resolutions
- Updated README and CLAUDE.md documentation
- Bumped version to 0.8.7

## Problem
When users ran `appshot init`, the default iPhone resolution (1284x2778) was outdated and would cause App Store rejection. The correct resolution for current iPhones is 1290x2796 or 1320x2868.

## Solution
Updated the init command defaults and all related code/tests to use the current App Store-compliant resolutions.

## Test Plan
- [x] All 588 tests passing
- [x] Lint passes with no issues
- [x] Tested locally with `npm link`
- [x] Verified `appshot init` creates correct resolutions
- [x] Built and tested in production project

🤖 Generated with Claude Code