### PR TITLE
fix: remove duplicate workflow triggers and increase test timeout

### DIFF
--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -1,11 +1,7 @@
 name: Unit Tests
 
 on:
-  workflow_call:  # Allow this workflow to be called by others
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_call:  # Called by ci.yml - this is the only trigger needed
 
 jobs:
   unit-tests:

--- a/.github/workflows/ci-visual.yml
+++ b/.github/workflows/ci-visual.yml
@@ -1,17 +1,7 @@
 name: Visual Tests
 
 on:
-  workflow_call:  # Allow this workflow to be called by others
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'src/core/compose.ts'
-      - 'src/core/render.ts'
-      - 'src/core/text-renderer.ts'
-      - 'src/commands/build.ts'
-      - 'tests/visual/**'
+  workflow_call:  # Called by ci.yml - this is the only trigger needed
 
 jobs:
   visual-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-01-25
+
+### 🐛 Fixed
+- **CI Workflow Deduplication**: Removed duplicate push/PR triggers from `ci-unit.yml` and `ci-visual.yml` that caused parallel workflow runs and allowed releases when standalone tests failed
+- **Test Timeout**: Increased `background-integration.test.ts` timeout to 60s for Windows CI stability
+
 ## [2.0.0] - 2026-01-25
 
 ### ✨ Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appshot-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Generate App Store–ready screenshots with frames, gradients, and captions",
   "bin": {
     "appshot": "bin/appshot.js"

--- a/tests/background-integration.test.ts
+++ b/tests/background-integration.test.ts
@@ -9,7 +9,7 @@ import type { BackgroundConfig, CaptionConfig, DeviceConfig } from '../src/types
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-describe('background integration', () => {
+describe('background integration', { timeout: 60000 }, () => {
   let tempDir: string;
   let screenshotBuffer: Buffer;
   let backgroundImagePath: string;


### PR DESCRIPTION
## Summary
- Remove push/PR triggers from `ci-unit.yml` and `ci-visual.yml` - these workflows are called by `ci.yml`, so having their own triggers caused duplicate runs
- Increase `background-integration.test.ts` timeout to 60s for Windows CI

## Problem
The v2.0.0 release was published even though the standalone Unit Tests workflow failed on Windows. This happened because:

1. `ci-unit.yml` had both `workflow_call` (for ci.yml to use) AND `push`/`pull_request` triggers
2. This caused **two separate workflow runs** on every push to main
3. The release job in `ci.yml` only waits for the workflow it calls, not the standalone run
4. If the called workflow passes but the standalone run fails, release still proceeds

## Test plan
- [ ] CI passes on all platforms
- [ ] Only one Unit Tests workflow runs per push (no duplicates)
- [ ] background-integration test no longer times out on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)